### PR TITLE
[ci] upgrade actions versions

### DIFF
--- a/.github/workflows/all-in-one.yml
+++ b/.github/workflows/all-in-one.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout with submodule
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/cmake-arm-cross-build.yml
+++ b/.github/workflows/cmake-arm-cross-build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true # without recursive
 
@@ -25,7 +25,7 @@ jobs:
       run: git -C vsf submodule update --init
 
     - name: arm-none-eabi-gcc
-      uses: carlosperate/arm-none-eabi-gcc-action@v1
+      uses: carlosperate/arm-none-eabi-gcc-action@v1.12.3
       with:
         release: ${{matrix.cc}}
     - name: install depends

--- a/.github/workflows/cmake-native-build.yml
+++ b/.github/workflows/cmake-native-build.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true # without recursive
 

--- a/.github/workflows/cmake-webassembly.yml
+++ b/.github/workflows/cmake-webassembly.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true # without recursive
 
@@ -25,7 +25,7 @@ jobs:
       shell: bash
 
     - name: install emsdk
-      uses: mymindstorm/setup-emsdk@v11
+      uses: mymindstorm/setup-emsdk@v16
 
     - name: Verify
       run: emcc -v

--- a/.github/workflows/repository_dispath.yml
+++ b/.github/workflows/repository_dispath.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.VSF_AIO }}
           script: |

--- a/.github/workflows/vsf-sync.yml
+++ b/.github/workflows/vsf-sync.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout with submodule
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.VSF_SYNC }}

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   windows-build:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
@@ -18,20 +18,25 @@ jobs:
         platform: [x86, x64]
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2019
         # https://docs.microsoft.com/en-us/visualstudio/install/visual-studio-build-numbers-and-release-dates?view=vs-2022
-        os: [windows-2019, windows-2022]
+        os: [windows-2019, windows-2022, windows-2025]
         include:
             - os: windows-2019
-              vs-version: '[17.0, 18)'
-            - os: windows-2022
               vs-version: '[16.0, 17)'
+            - os: windows-2022
+              vs-version: '[17.0, 18)'
+            - os: windows-2025
+              vs-version: '[18.0, 19)'
 
     steps:
     - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v3
+      with:
+        vs-version: ${{ matrix.vs-version }}
 
     - name: Checkout With Submodule
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
+        persist-credentials: true
         submodules: true # without recursive
 
     - name: Checkout VSF Submodule
@@ -48,9 +53,9 @@ jobs:
       run: msbuild /m /p:Configuration=${{matrix.build_config}} project/${{matrix.project_name}}/vsf_linux.sln /property:Configuration=${{matrix.build_config}} /property:Platform=${{matrix.platform}}
 
     - name: Test
-      # TODO: check why only work for wexpect-uv==0.0.2
+      # wexpect (was wexpect-uv==0.0.2)
       run: |
-        pip install pytest pytest-bdd wexpect-uv==0.0.2 simple-hexdump
+        pip install pytest pytest-bdd wexpect simple-hexdump
         if [ ${{matrix.platform}} = x64 ]; then
           template_file="${{github.workspace}}/project/${{matrix.project_name}}/x64/${{matrix.build_config}}/vsf_linux.exe"
         else


### PR DESCRIPTION
## Summary

Upgrade all GitHub Actions to latest stable versions.

## Changes

| File | Action | Old | New |
|---|---|---|---|
| all-in-one.yml | actions/checkout | @v2 | @v4 |
| cmake-arm-cross-build.yml | actions/checkout | @v2 | @v4 |
| cmake-arm-cross-build.yml | carlosperate/arm-none-eabi-gcc-action | @v1 | @v1.12.3 |
| cmake-native-build.yml | actions/checkout | @v2 | @v4 |
| cmake-webassembly.yml | actions/checkout | @v2 | @v4 |
| cmake-webassembly.yml | mymindstorm/setup-emsdk | @v11 | @v16 |
| repository_dispath.yml | actions/github-script | @v6 | @v7 |
| vsf-sync.yml | actions/checkout | @v2 | @v4 |
| windows-build.yml | actions/checkout | @v2 | @v4 |
| windows-build.yml | microsoft/setup-msbuild | @v1.0.2 | @v3 |